### PR TITLE
Add logic to stop Docker builds on Forked Repos

### DIFF
--- a/.github/workflows/docker-image-build-and-push-manual.yaml
+++ b/.github/workflows/docker-image-build-and-push-manual.yaml
@@ -14,7 +14,7 @@ jobs:
         # perform secret check & put boolean result as an output
         shell: bash
         run: |
-          if [ "${{ secrets.DOCKER_USER }}" != '' ]; then
+          if [ "${{ secrets.DOCKER_USER }}" == '' ]; then
             echo "available=true" >> $GITHUB_OUTPUT;
           else
             echo "available=false" >> $GITHUB_OUTPUT;

--- a/.github/workflows/docker-image-build-and-push-manual.yaml
+++ b/.github/workflows/docker-image-build-and-push-manual.yaml
@@ -8,24 +8,38 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
+      - name: Check if Docker Secrets are present
+        id: Docker
+        # perform secret check & put boolean result as an output
+        shell: bash
+        run: |
+          if [ "${{ secrets.DOCKER_USER }}" != '' ]; then
+            echo "available=true" >> $GITHUB_OUTPUT;
+          else
+            echo "available=false" >> $GITHUB_OUTPUT;
+          fi
+
       - uses: actions/checkout@v4
       - name: Log in to Docker Hub
+        if: ${{ steps.Docker.outputs.available != 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
+    
       - name: Install Buildx
+        if: ${{ steps.Docker.outputs.available != 'true' }}
         id: buildx
         uses: docker/setup-buildx-action@master
-
+          
       - name: Get Current Date # get the date of the build
+        if: ${{ steps.Docker.outputs.available != 'true' }}
         id: date
         run: echo "date=$(date +'%Y-%m-%d--%M-%S')" >> "$GITHUB_OUTPUT"
 
       - name: Build & Push - Latest
+        if: ${{ steps.Docker.outputs.available != 'true' }}
         run: |
           docker buildx build --squash --push \
           -t mrlolf/honeygainautoclaim:${{ steps.date.outputs.date }} \

--- a/.github/workflows/docker-image-build-and-push.yml
+++ b/.github/workflows/docker-image-build-and-push.yml
@@ -1,30 +1,46 @@
 name: Build and Push to Dockerhub
 
-on: [push]
-#  schedule:
-#    - cron: '0 1 * * *'
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  push:
+    branches: ['main']
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
+      - name: Check if Docker Secrets are present
+        id: Docker
+        # perform secret check & put boolean result as an output
+        shell: bash
+        run: |
+          if [ "${{ secrets.DOCKER_USER }}" != '' ]; then
+            echo "available=true" >> $GITHUB_OUTPUT;
+          else
+            echo "available=false" >> $GITHUB_OUTPUT;
+          fi
+
       - uses: actions/checkout@v4
       - name: Log in to Docker Hub
+        if: ${{ steps.Docker.outputs.available != 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
     
       - name: Install Buildx
+        if: ${{ steps.Docker.outputs.available != 'true' }}
         id: buildx
         uses: docker/setup-buildx-action@master
           
       - name: Get Current Date # get the date of the build
+        if: ${{ steps.Docker.outputs.available != 'true' }}
         id: date
         run: echo "date=$(date +'%Y-%m-%d--%M-%S')" >> "$GITHUB_OUTPUT"
 
       - name: Build & Push - Latest
+        if: ${{ steps.Docker.outputs.available != 'true' }}
         run: |
           docker buildx build --squash --push \
           -t mrlolf/honeygainautoclaim:${{ steps.date.outputs.date }} \

--- a/.github/workflows/docker-image-build-and-push.yml
+++ b/.github/workflows/docker-image-build-and-push.yml
@@ -2,7 +2,7 @@ name: Build and Push to Dockerhub
 
 on:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 0 * * 1'
   push:
     branches: ['main']
 

--- a/.github/workflows/docker-image-build-and-push.yml
+++ b/.github/workflows/docker-image-build-and-push.yml
@@ -15,7 +15,7 @@ jobs:
         # perform secret check & put boolean result as an output
         shell: bash
         run: |
-          if [ "${{ secrets.DOCKER_USER }}" != '' ]; then
+          if [ "${{ secrets.DOCKER_USER }}" == '' ]; then
             echo "available=true" >> $GITHUB_OUTPUT;
           else
             echo "available=false" >> $GITHUB_OUTPUT;


### PR DESCRIPTION
Added logic to stop Docker builds on forked repos.

Added weekly rebuild to make sure newest ChainGuard images always rebuild. Currently with Dependabot automerge, it does not trigger additional workflows so we have to manually kick off the docker image rebuild.